### PR TITLE
code_of_conduct.mdの追加

### DIFF
--- a/code_of_conduct.md
+++ b/code_of_conduct.md
@@ -1,0 +1,41 @@
+# Code of Conduct
+
+We, the organizers of **Nodeschool Tokyo**, are dedicated to providing a
+harassment-free community for everyone, regardless of sex, gender identity or
+expression, sexual orientation, disability, physical appearance, age, body
+size, race, nationality, or religious beliefs. We do not tolerate harassment of
+community members in any form. Participants violating these rules may be
+sanctioned or expelled from the community at the discretion of the organizers
+of **Nodeschool Tokyo**.
+
+Harassment includes offensive verbal or written comments related to sex, gender
+identity or expression, sexual orientation, disability, physical appearance,
+age, body size, race, nationality, or religious beliefs, deliberate
+intimidation, threats, stalking, following, harassing photography or recording,
+sustained disruption of talks or other events, inappropriate physical contact,
+and unwelcome sexual attention. Sexual language and imagery is not approprate
+for any events at **Nodeschool Tokyo** meetups or in any related
+communication channels. Community members asked to stop any harassing behavior
+are expected to comply immediately. Sponsors and presenters are also subject to
+the anti-harassment policy.
+
+If a community member engages in harassing behavior, the organizers of
+**Nodeschool Tokyo** may take any action they deem appropriate, including
+warning the offender or expulsion from the community. If you are being
+harassed, notice that someone else is being harassed, or have any concerns,
+please contact an organizer immediately.
+
+### **Nodeschool Tokyo**
+
+* Organizers: **Sota Yamashtia**
+* Meetup URL: **http://nodejs.connpass.com/**
+
+**If you have questions or feedback about this Code of Conduct please contact
+one of the organizers.**
+
+The organizers of the above communities developed this Code of Conduct to
+govern their respective events and communication channels. We used [PDX
+Python's anti-harassment policy](http://www.meetup.com/pdxpython/pages/Code_of_Conduct/)
+and the [Geek Feminism Conference anti-harassment policy](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy)
+as a starting point. This Code of Conduct, like its inspirations, is licensed under
+the [Creative Commons Zero license](http://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
このPRは、https://github.com/nodeschool/tokyo/issues/4 を進めるにあたっての提案です。

他国のCoCをいくつか見てみましたが、
[template](https://github.com/nodeschool/organizers/blob/master/codeofconduct-template.md)を元に**Chapter Name**を置換し、
OrganizersとMeetup URLの情報を加えたものを置くのが一般的なようです。

例：
- https://github.com/nodeschool/chennai/blob/master/README.md
- https://github.com/nodeschool/boston/wiki/Code-of-conduct

上に習ってTokyo向けのものを作ってみました。これを元に日本語に翻訳したmdを置くようにすると管理しやすくなるかと思いますが、いかがでしょう？
